### PR TITLE
Added Tenths Precision to temp display

### DIFF
--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -11,6 +11,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
+    PRECISION_TENTHS,
     CONF_HOST,
     CONF_TOKEN
 )
@@ -140,7 +141,7 @@ class SalusThermostat(ClimateEntity):
     @property
     def precision(self):
         """Return the precision of the system."""
-        return self._coordinator.data.get(self._idx).precision
+        return PRECISION_TENTHS
 
     @property
     def current_temperature(self):


### PR DESCRIPTION
Current precision for displaying the temperature is HALVES. I need more precise values for current temp to use it in history graphs. The purpose is to have a better understanding on how efficient to heating system is. In orther to do this I imported the PRECISION_TENTHS from homeassistant and use it for return values.
Happy new year! :)