### PR TITLE
Fix: HVACMode.OFF was mapped to "auto" in async_set_hvac_mode

### DIFF
--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -230,9 +230,11 @@ class SalusThermostat(ClimateEntity):
         await self._gateway.set_climate_device_fan_mode(self._idx, mode)
         await self._coordinator.async_request_refresh()
 
-    async def async_set_hvac_mode(self, hvac_mode):
-        """Set operation mode (auto, heat, cool)."""
-        if hvac_mode == HVACMode.HEAT:
+   async def async_set_hvac_mode(self, hvac_mode):
+        """Set operation mode (off, auto, heat, cool)."""
+        if hvac_mode == HVACMode.OFF:
+            mode = "off"
+        elif hvac_mode == HVACMode.HEAT:
             mode = "heat"
         elif hvac_mode == HVACMode.COOL:
             mode = "cool"


### PR DESCRIPTION
## Problem
`async_set_hvac_mode` only maps HEAT and COOL explicitly; everything else — including `HVACMode.OFF` — falls into the `else` branch and is sent to the gateway as `"auto"`. Turning a climate device **off** therefore actually switches it **on** (auto mode). This affects any UI path that sets hvac_mode to off, most visibly Apple Home via HA's HomeKit Bridge.

## Fix
Add an explicit `HVACMode.OFF → "off"` mapping.

## Tested
On a UG800 gateway with 5× ALTHRSQ800WRF zone thermostats (see also epoplavskis/pyit600 PR #55, which adds off-mode support for this device family in the library): turning zones off from Apple Home now correctly puts them in standby, verified on the wall units.

Note: for devices whose library-side `set_climate_device_mode` doesn't handle `HVAC_MODE_OFF` yet, this change is a no-op improvement — the mode string simply becomes correct.