### PR TITLE
Distinguish a gateway that is still booting from a wrong EUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ When you are done with configuration you should see your devices in Configuratio
 
 If you can't connect using EUID written down on the bottom of your gateway (which looks something like `001E5E0D32906128`), try using `0000000000000000` as EUID.
 
+## "Authentication error" right after a restart or a power cut
+
+If the log shows
+
+```
+Authentication error: check if you have specified gateway's EUID correctly.
+```
+
+only when Home Assistant and the gateway started at the same time, the EUID is
+almost certainly fine and there is nothing to change. `pyit600` reports that
+error whenever the request to `/deviceid/read` did not go through while a plain
+`GET /` on the gateway still answered - which is what a gateway looks like when
+its web server is up but its device API is not serving yet, i.e. one that has
+not finished booting. Home Assistant retries on its own until the gateway
+answers.
+
+A genuinely wrong EUID fails differently: the gateway replies immediately with a
+short body that cannot be decrypted, and the integration reports that the reply
+could not be decrypted and stops rather than retrying.
+
 Also check if you have "Local Wifi Mode" enabled:
 * Open Smart Home app on your phone
 * Sign in

--- a/custom_components/salus/__init__.py
+++ b/custom_components/salus/__init__.py
@@ -4,6 +4,7 @@ import time
 from asyncio import sleep
 
 from homeassistant import config_entries, core
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
 from homeassistant.const import (
@@ -11,7 +12,11 @@ from homeassistant.const import (
     CONF_TOKEN
 )
 
-from pyit600.exceptions import IT600AuthenticationError, IT600ConnectionError
+from pyit600.exceptions import (
+    IT600AuthenticationError,
+    IT600CommandError,
+    IT600ConnectionError,
+)
 from pyit600.gateway import IT600Gateway
 
 from .config_flow import CONF_FLOW_TYPE, CONF_USER
@@ -55,11 +60,29 @@ async def async_setup_gateway_entry(hass: core.HomeAssistant, entry: config_entr
                 else:
                     await sleep(3)
     except IT600ConnectionError as ce:
-        _LOGGER.error("Connection error: check if you have specified gateway's HOST correctly.")
-        return False
+        raise ConfigEntryNotReady(
+            f"Could not reach the iT600 gateway at {host}. "
+            "Check that the host is correct and the gateway is powered on."
+        ) from ce
     except IT600AuthenticationError as ae:
-        _LOGGER.error("Authentication error: check if you have specified gateway's EUID correctly.")
-        return False
+        # Despite its name, pyit600 raises this only when the request to
+        # /deviceid/read timed out while a plain GET on the gateway still
+        # answers - that is, the web server is up but the device API is not
+        # serving yet. A gateway that is still booting looks exactly like
+        # this, so retry rather than give up. A wrong EUID does not come out
+        # here; it is answered quickly and fails to decrypt, which pyit600
+        # reports as IT600CommandError below.
+        raise ConfigEntryNotReady(
+            f"The iT600 gateway at {host} is reachable but its device API is "
+            "not responding yet; it is probably still starting up."
+        ) from ae
+    except IT600CommandError as cmde:
+        # The gateway answered, but the reply could not be decrypted with the
+        # configured EUID. Retrying will never fix that, so fail for good.
+        raise ConfigEntryError(
+            f"The iT600 gateway at {host} replied with data that could not be "
+            "decrypted. Check that the EUID is correct."
+        ) from cmde
 
     hass.data[DOMAIN][entry.entry_id] = gateway
 


### PR DESCRIPTION
## The problem

After a power cut, Home Assistant finished booting before the UGE600 gateway did and logged:

```
ERROR (MainThread) [custom_components.salus] Authentication error: check if you have specified gateway's EUID correctly.
```

The EUID was correct and unchanged since the integration was first set up.

The real damage was what happened next. `async_setup_gateway_entry` returns `False`, and Home Assistant treats that as a *permanent* setup failure: the entry is marked `setup_error` and is **never retried**. All six thermostats stayed `unavailable` for 25 minutes, until the config entry was reloaded by hand. Integrations that raise `ConfigEntryNotReady` (`huawei_solar`, `jellyfin`) recovered from the same outage on their own.

## `IT600AuthenticationError` does not mean the EUID is wrong

`pyit600` raises it from exactly one place, `IT600Gateway.connect()`:

```python
except IT600ConnectionError as ae:
    try:
        with async_timeout.timeout(self._request_timeout):
            await self._session.get(f"http://{self._host}:{self._port}/")
    except Exception:
        raise IT600ConnectionError("...check if you have specified host/IP address correctly") from ae

    raise IT600AuthenticationError("...check if you have specified EUID correctly") from ae
```

It is reached only when the encrypted `POST /deviceid/read` failed with a timeout or a connection error **and** a plain `GET /` on the same host still answered. `aiohttp` does not raise on the gateway's `404`, so that probe succeeds as soon as the web server is up.

So the branch fires exactly when the gateway's web server is serving but its device API is not — which is what a gateway that has not finished booting looks like. It is a transient condition, not a credentials problem.

## A wrong EUID takes a different path

Measured against a real UGE600, replaying the protocol from `IT600Encryptor`:

| request | response | result |
| --- | --- | --- |
| correct EUID | HTTP 200, 19952 bytes, 64 ms | decrypts, `status: success`, 9 devices |
| wrong EUID | HTTP 200, 32 bytes, 10 ms | `ValueError: Invalid padding bytes` |

The gateway answers a request it cannot decrypt straight away, and the short reply then fails to decrypt on the way back. `_make_encrypted_request` catches that in its bare `except Exception` and raises `IT600CommandError` — which this integration does not catch at all, so it escapes as an unhandled traceback.

## The change

The three errors now map onto the three outcomes Home Assistant provides:

| pyit600 error | what it means | Home Assistant |
| --- | --- | --- |
| `IT600ConnectionError` | gateway unreachable | `ConfigEntryNotReady` — retry with backoff |
| `IT600AuthenticationError` | web server up, device API not serving yet | `ConfigEntryNotReady` — retry with backoff |
| `IT600CommandError` | reply will not decrypt, i.e. wrong EUID | `ConfigEntryError` — permanent, no retry |

A booting gateway recovers unattended. A wrong EUID fails at once, names the real cause, and is not retried forever.

The README gets a Troubleshooting entry, since the misleading message is what sends people to that section in the first place.

## Notes

- The `manifest.json` version is deliberately left alone, so you can pick it at release time.
- Running in production on HA 2026.8.1 with a UGE600 and 6 thermostats.
- Not yet exercised by a real outage — the classification is verified against the physical gateway, but the retry path itself will only be proven at the next power cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)